### PR TITLE
feat: implement DOF redesign concept across the site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 # next.js
 /.next/
 /out/
+*.tsbuildinfo
 
 # production
 /build
@@ -30,3 +31,4 @@ yarn-error.log*
 .env.test.local
 .env.production.local
 .env
+.gstack/

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,40 +1,176 @@
 @import "tailwindcss";
 
 @plugin "@tailwindcss/forms";
-@plugin "@tailwindcss/typography";
 
+/* Font families are wired to the next/font CSS variables set in layout.tsx.
+   `inline` so the utilities resolve directly to those variables. */
 @theme inline {
-  --font-sans: var(--font-roboto);
+  --font-sans: var(--font-public-sans);
+  --font-serif: var(--font-source-serif);
+}
+
+/* Design tokens for the DOF redesign. Emitted as CSS custom properties on
+   :root so they can also be referenced from inline styles (e.g. focus rings). */
+@theme {
+  --color-accent: #1a4d7a;
+  --color-accent-tint: #eaeff3; /* accent at ~9% over white — badge fills */
+  --color-paper: #fdfdfc; /* page background */
+  --color-card: #ffffff;
+  --color-edge: #e7e7e5; /* card / control borders */
+  --color-line: #ececec; /* hairline section borders */
+  --color-line-soft: #f0f0ef; /* row dividers */
+  --color-field: #f4f4f3; /* input / hover backgrounds */
+  --color-ink: #18181b; /* primary text */
 }
 
 @layer base {
-  h1 {
-    @apply text-3xl pt-4 pb-4;
-  }
-  h2 {
-    @apply text-2xl pt-4 pb-2;
-  }
-  h3 {
-    @apply text-xl pt-4 pb-1;
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
   }
 
-  p {
-    @apply py-1;
+  body {
+    background: var(--color-paper);
+    color: var(--color-ink);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+
+  ::selection {
+    background: rgba(26, 77, 122, 0.18); /* fallback for no color-mix support */
+    background: color-mix(in srgb, var(--color-accent) 18%, transparent);
   }
 
   a {
-    @apply text-blue-600 underline;
+    color: inherit;
+    text-decoration: none;
   }
 
-  ul {
-    @apply list-disc list-inside;
+  button {
+    font-family: inherit;
   }
 
-  li {
-    @apply py-1;
+  /* Visible keyboard focus for every interactive element. Pointer focus stays
+     quiet via :focus-visible. Search inputs suppress their own outline and
+     surface focus on the wrapper instead (focus-within ring). */
+  :focus-visible {
+    outline: 2px solid var(--color-accent);
+    outline-offset: 2px;
   }
 
-  p code {
-    @apply bg-red-200 p-1 rounded-xs;
+  ::-webkit-scrollbar {
+    width: 11px;
+    height: 11px;
   }
+  ::-webkit-scrollbar-thumb {
+    background: #d4d4d8;
+    border-radius: 8px;
+    border: 3px solid var(--color-paper);
+  }
+}
+
+@keyframes sugIn {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ── Document reading body ───────────────────────────────────────────────
+   Styles the sanitized DOF note HTML rendered via dangerouslySetInnerHTML.
+   The wrapper sets font-size inline (reader zoom); headings use em units so
+   they scale with it. */
+.dof-prose {
+  font-family: var(--font-serif), Georgia, serif;
+  line-height: 1.78;
+  color: #27272a;
+  max-width: 64ch;
+  overflow-wrap: anywhere; /* never overflow the column at high reader zoom */
+}
+.dof-prose p {
+  margin-bottom: 1.25em;
+}
+.dof-prose p:last-child {
+  margin-bottom: 0;
+}
+.dof-prose h1,
+.dof-prose h2,
+.dof-prose h3,
+.dof-prose h4 {
+  font-family: var(--font-serif), Georgia, serif;
+  font-weight: 600;
+  line-height: 1.25;
+  color: var(--color-ink);
+  scroll-margin-top: 84px;
+}
+.dof-prose h1 {
+  font-size: 1.3em;
+  margin: 1.4em 0 0.5em;
+}
+.dof-prose h2 {
+  font-size: 1.15em;
+  margin: 1.6em 0 0.6em;
+}
+.dof-prose h3 {
+  font-size: 1.05em;
+  margin: 1.4em 0 0.5em;
+}
+.dof-prose strong,
+.dof-prose b {
+  font-weight: 600;
+}
+.dof-prose a {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.dof-prose ul,
+.dof-prose ol {
+  margin: 0 0 1.25em;
+  padding-left: 1.4em;
+}
+.dof-prose ul {
+  list-style: disc;
+}
+.dof-prose ol {
+  list-style: decimal;
+}
+.dof-prose li {
+  margin-bottom: 0.4em;
+}
+.dof-prose img {
+  max-width: 100%;
+  height: auto;
+}
+.dof-prose table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88em;
+  margin-bottom: 1.25em;
+}
+.dof-prose th,
+.dof-prose td {
+  border: 1px solid var(--color-edge);
+  padding: 6px 10px;
+  vertical-align: top;
+  text-align: left;
+}
+.dof-prose .overflow-scroll {
+  overflow-x: auto;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,19 +2,26 @@ import "./globals.css";
 
 import type { Metadata, Viewport } from "next";
 import type { ReactNode } from "react";
-import { Roboto } from "next/font/google";
+import { Public_Sans, Source_Serif_4 } from "next/font/google";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { Analytics } from "@vercel/analytics/next";
 
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 
-const roboto = Roboto({
-  weight: ["300", "400", "500", "700", "900"],
+const publicSans = Public_Sans({
+  weight: ["400", "500", "600", "700"],
   style: ["normal", "italic"],
   subsets: ["latin"],
   display: "swap",
-  variable: "--font-roboto",
+  variable: "--font-public-sans",
+});
+
+const sourceSerif = Source_Serif_4({
+  weight: ["400", "500", "600", "700"],
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-source-serif",
 });
 
 const gaId = process.env.NEXT_PUBLIC_GA_TRACKING_ID;
@@ -22,16 +29,17 @@ const gaId = process.env.NEXT_PUBLIC_GA_TRACKING_ID;
 export const metadata: Metadata = {
   metadataBase: new URL("https://dof.toniotgz.com"),
   title: {
-    default: "Diaro Oficial de la Fedaración",
-    template: "%s | Diaro Oficial de la Fedaración",
+    default: "Diario Oficial de la Federación",
+    template: "%s | Diario Oficial de la Federación",
   },
-  description: "Diario Oficial de la Federación",
+  description:
+    "El registro oficial de México, al alcance de una búsqueda. Decretos, acuerdos, normas y resoluciones publicados por el Estado mexicano.",
   openGraph: {
     type: "website",
     locale: "es_MX",
     url: "https://dof.toniotgz.com/",
-    siteName: "Diaro Oficial de la Fedaración",
-    title: "Diaro Oficial de la Fedaración",
+    siteName: "Diario Oficial de la Federación",
+    title: "Diario Oficial de la Federación",
   },
   twitter: {
     card: "summary_large_image",
@@ -46,25 +54,34 @@ export const metadata: Metadata = {
     shortcut: "/favicon.ico",
     apple: "/apple-touch-icon.png",
     other: [
-      { rel: "mask-icon", url: "/safari-pinned-tab.svg", color: "#6c6c6c" },
+      { rel: "mask-icon", url: "/safari-pinned-tab.svg", color: "#1a4d7a" },
     ],
   },
   manifest: "/site.webmanifest",
-  other: { "msapplication-TileColor": "#ffc40d" },
+  other: { "msapplication-TileColor": "#1a4d7a" },
 };
 
 export const viewport: Viewport = {
-  themeColor: "#ffffff",
+  themeColor: "#fdfdfc",
 };
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="es" className={roboto.variable}>
-      <body className="font-sans antialiased flex flex-col items-stretch min-h-screen">
+    <html
+      lang="es"
+      className={`${publicSans.variable} ${sourceSerif.variable}`}
+    >
+      <body className="font-sans antialiased flex min-h-screen flex-col">
+        <a
+          href="#contenido"
+          className="sr-only rounded-md bg-accent px-4 py-2 text-[14px] font-semibold text-white focus:not-sr-only focus:absolute focus:left-4 focus:top-3 focus:z-[60]"
+        >
+          Saltar al contenido
+        </a>
         <Header />
-        <main className="grow w-full max-w-(--breakpoint-lg) mx-auto py-12 px-4 overflow-hidden sm:px-6 lg:px-8">
+        <div id="contenido" className="grow">
           {children}
-        </main>
+        </div>
         <Footer />
         <Analytics />
       </body>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -2,21 +2,23 @@ import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <>
-      <h3 className="text-center text-5xl leading-6 font-light text-gray-900 mt-20">
+    <main className="mx-auto flex max-w-[600px] flex-col items-center px-7 py-32 text-center">
+      <span className="font-serif text-[64px] font-semibold leading-none tracking-[-0.02em] text-accent">
         404
-      </h3>
-      <h3 className="text-center text-lg leading-6 font-medium text-gray-800">
-        Page Not Found
-      </h3>
-      <div className="mt-5 text-center">
-        <Link
-          href="/"
-          className="uppercase no-underline inline-flex items-center justify-center px-4 py-2 border border-transparent font-medium rounded-md text-blue-700 bg-blue-100 hover:bg-blue-50 focus:outline-hidden focus:border-blue-300 focus:ring-2 focus:ring-blue-300 active:bg-blue-200 transition ease-in-out duration-150 sm:text-sm sm:leading-5"
-        >
-          Return to homepage
-        </Link>
-      </div>
-    </>
+      </span>
+      <h1 className="mt-4 font-serif text-[22px] font-semibold tracking-[-0.01em]">
+        Página no encontrada
+      </h1>
+      <p className="mt-2 text-[15px] text-zinc-500">
+        No encontramos la publicación que buscas. Puede que el enlace haya
+        cambiado o que el documento ya no esté disponible.
+      </p>
+      <Link
+        href="/"
+        className="mt-8 inline-flex items-center rounded-[10px] bg-accent px-5 py-[10px] text-[14px] font-semibold text-white transition hover:brightness-110"
+      >
+        Volver al inicio
+      </Link>
+    </main>
   );
 }

--- a/app/notas/[id]/page.tsx
+++ b/app/notas/[id]/page.tsx
@@ -1,11 +1,18 @@
+import Link from "next/link";
 import { cache } from "react";
 import { format, parseISO } from "date-fns";
+import { es } from "date-fns/locale";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import { getNoteFiles } from "@/lib/aws";
 import { getNote, type Note } from "@/lib/getNote";
+import { getSampleNote } from "@/lib/sampleDocs";
+import { deriveTipo } from "@/lib/recentNotes";
 import { removeTags } from "@/lib/sanitize";
+import { buildToc } from "@/lib/toc";
+import ReadingPane from "@/components/reader/ReadingPane";
+import DocToc from "@/components/reader/DocToc";
 
 const BASE_URL = "https://dof.toniotgz.com";
 
@@ -32,9 +39,19 @@ const loadNote = cache(async (id: string): Promise<Note | null> => {
     return await getNote(id);
   } catch (error) {
     console.error(error);
-    return null;
+    // When S3 and the upstream DOF source are both unavailable, serve concept
+    // content for known sample ids so the redesign stays navigable.
+    return getSampleNote(id);
   }
 });
+
+function formatLongDate(iso: string): string {
+  try {
+    return format(parseISO(iso), "d 'de' MMMM 'de' yyyy", { locale: es });
+  } catch {
+    return iso;
+  }
+}
 
 export async function generateMetadata({
   params,
@@ -45,7 +62,7 @@ export async function generateMetadata({
   const note = await loadNote(id);
   if (!note) return {};
 
-  const title = `DOF | ${note.metadata.title.substring(0, 60)}`;
+  const title = note.metadata.title.substring(0, 70);
   return {
     title,
     alternates: { canonical: `/notas/${id}` },
@@ -67,10 +84,14 @@ export default async function NotePage({
   const note = await loadNote(id);
   if (!note) notFound();
 
+  const tipo = deriveTipo(note.metadata.title);
+  const fecha = formatLongDate(note.metadata.published_at);
+  const { html, toc } = buildToc(note.content);
+
   const jsonLd = {
     "@context": "https://schema.org",
     "@type": "Article",
-    headline: `DOF | ${note.metadata.title.substring(0, 60)}`,
+    headline: note.metadata.title.substring(0, 70),
     image: [`${BASE_URL}/apple-touch-icon.png`],
     datePublished: note.metadata.published_at,
     dateModified: note.metadata.published_at,
@@ -87,17 +108,83 @@ export default async function NotePage({
   };
 
   return (
-    <article>
+    <main className="mx-auto max-w-[1140px] animate-[fadeUp_0.3s_ease] px-4 pb-24 pt-7 sm:px-7">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{
           __html: JSON.stringify(jsonLd).replace(/</g, "\\u003c"),
         }}
       />
-      <div>
-        Fecha: {format(parseISO(note.metadata.published_at), "dd/MM/yyyy")}
+
+      <Link
+        href="/"
+        className="mb-2 inline-flex items-center gap-[7px] py-2 text-[13.5px] text-zinc-500 transition-colors hover:text-accent"
+      >
+        <svg
+          width="15"
+          height="15"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2.2}
+          aria-hidden="true"
+        >
+          <path d="m15 18-6-6 6-6" />
+        </svg>
+        Volver al inicio
+      </Link>
+
+      <div className="grid grid-cols-1 items-start gap-x-[54px] gap-y-10 lg:grid-cols-[minmax(0,1fr)_296px]">
+        {/* Reading column */}
+        <article>
+          <span className="mb-[18px] inline-block rounded-[7px] bg-accent-tint px-[11px] py-1 text-[11px] font-semibold tracking-[0.05em] text-accent">
+            {tipo}
+          </span>
+          <h1 className="mb-[18px] text-pretty font-serif text-[28px] font-semibold leading-[1.18] tracking-[-0.015em] sm:text-[34px]">
+            {note.metadata.title}
+          </h1>
+          <div className="flex flex-wrap items-center gap-x-[18px] gap-y-[10px] border-b border-line pb-[22px] text-[13.5px] text-zinc-500">
+            <span>{fecha}</span>
+          </div>
+
+          <ReadingPane content={html} title={note.metadata.title} />
+        </article>
+
+        {/* Sidebar */}
+        <aside className="flex flex-col gap-4 lg:sticky lg:top-[84px]">
+          <div className="rounded-2xl border border-edge bg-white px-[22px] py-5">
+            <span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-zinc-400">
+              Datos de publicación
+            </span>
+            <dl className="mt-[14px] flex flex-col gap-[13px]">
+              <div>
+                <dt className="mb-[2px] text-[12px] text-zinc-400">
+                  Fecha de publicación
+                </dt>
+                <dd className="text-[14px] font-medium text-zinc-800">
+                  {fecha}
+                </dd>
+              </div>
+              <div>
+                <dt className="mb-[2px] text-[12px] text-zinc-400">
+                  Tipo de documento
+                </dt>
+                <dd className="text-[14px] font-medium text-zinc-800">
+                  {tipo}
+                </dd>
+              </div>
+              <div>
+                <dt className="mb-[2px] text-[12px] text-zinc-400">Folio DOF</dt>
+                <dd className="text-[14px] font-medium tabular-nums text-zinc-800">
+                  {id}
+                </dd>
+              </div>
+            </dl>
+          </div>
+
+          {toc.length > 0 && <DocToc items={toc} />}
+        </aside>
       </div>
-      <div dangerouslySetInnerHTML={{ __html: note.content }} />
-    </article>
+    </main>
   );
 }

--- a/app/notas/page.tsx
+++ b/app/notas/page.tsx
@@ -1,3 +1,59 @@
-export default function Notas() {
-  return <>Próximamente más</>;
+import Link from "next/link";
+import type { Metadata } from "next";
+
+import { getRecentDocs } from "@/lib/recentNotes";
+
+export const metadata: Metadata = {
+  title: "Ediciones recientes",
+  description: "Publicaciones recientes del Diario Oficial de la Federación.",
+};
+
+export default async function NotasPage() {
+  const docs = await getRecentDocs(30);
+
+  return (
+    <main className="mx-auto max-w-[1100px] px-4 pb-[72px] pt-12 sm:px-7">
+      <header className="mb-2">
+        <h1 className="font-serif text-[32px] font-semibold tracking-[-0.02em]">
+          Ediciones recientes
+        </h1>
+        <p className="mt-2 text-[15px] text-zinc-500">
+          Publicaciones más recientes del Diario Oficial de la Federación.
+        </p>
+      </header>
+
+      <ul className="mt-6 border-t border-line">
+        {docs.map((doc, index) => (
+          <li key={doc.id}>
+            <Link
+              href={`/notas/${doc.id}`}
+              className="flex items-center gap-[22px] border-b border-line-soft px-[6px] py-5 text-left transition-colors hover:bg-[#fafafa]"
+            >
+              <span className="w-[26px] flex-none text-center font-serif text-[17px] text-[#c4c4c9]">
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <span className="hidden w-[104px] flex-none sm:block">
+                <span className="inline-block rounded-md bg-accent-tint px-[9px] py-[3px] text-[10.5px] font-semibold tracking-[0.04em] text-accent">
+                  {doc.tipo}
+                </span>
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-[15.5px] font-medium leading-[1.35] text-zinc-800">
+                  {doc.titulo}
+                </span>
+                {doc.dependencia && (
+                  <span className="mt-[3px] block text-[13px] text-zinc-400">
+                    {doc.dependencia}
+                  </span>
+                )}
+              </span>
+              <span className="hidden w-[110px] flex-none text-right text-[12.5px] text-[#bcbcc2] sm:block">
+                {doc.fecha}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,173 @@
-export default function Home() {
-  return <>Próximamente más</>;
+import Link from "next/link";
+import { format, parseISO } from "date-fns";
+import { es } from "date-fns/locale";
+
+import HeroSearch from "@/components/home/HeroSearch";
+import { getRecentDocs } from "@/lib/recentNotes";
+
+const CHIPS = ["Edición de hoy", "Por dependencia", "Por fecha", "Búsqueda avanzada"];
+
+function capitalize(text: string): string {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
+function ChevronRight({ className }: { className?: string }) {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2.2}
+      aria-hidden="true"
+      className={className}
+    >
+      <path d="m9 18 6-6-6-6" />
+    </svg>
+  );
+}
+
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string | string[] }>;
+}) {
+  const { q } = await searchParams;
+  const initialQuery = Array.isArray(q) ? (q[0] ?? "") : (q ?? "");
+
+  const docs = await getRecentDocs(6);
+  const editionDate = docs[0]?.publishedAt
+    ? parseISO(docs[0].publishedAt)
+    : new Date();
+
+  const longDate = capitalize(
+    format(editionDate, "EEEE d 'de' MMMM 'de' yyyy", { locale: es }),
+  );
+  const dayLine = capitalize(
+    format(editionDate, "EEEE d 'de' MMMM", { locale: es }),
+  );
+  const yearLine = format(editionDate, "'de' yyyy", { locale: es });
+
+  return (
+    <main>
+      {/* Hero search */}
+      <section className="mx-auto max-w-[760px] px-7 pb-[52px] pt-[88px] text-center">
+        <div className="mb-7 inline-flex items-center gap-2 rounded-full border border-edge px-[13px] py-[5px] text-[12.5px] text-zinc-500">
+          <span className="h-[7px] w-[7px] rounded-full bg-[#16a34a]" />
+          Edición publicada · {longDate}
+        </div>
+        <h1 className="mx-auto mb-[18px] max-w-[620px] text-balance font-serif text-[40px] font-semibold leading-[1.06] tracking-[-0.025em] sm:text-[50px]">
+          El registro oficial de México, al alcance de una búsqueda
+        </h1>
+        <p className="mx-auto mb-9 max-w-[480px] text-[18px] leading-[1.5] text-zinc-500">
+          Encuentra decretos, acuerdos, normas y resoluciones publicados por el
+          Estado mexicano.
+        </p>
+
+        <HeroSearch key={initialQuery} docs={docs} initialQuery={initialQuery} />
+
+        {/* Quick chips */}
+        <div className="mt-6 flex flex-wrap justify-center gap-[9px]">
+          {CHIPS.map((chip) => (
+            <Link
+              key={chip}
+              href="/notas"
+              className="rounded-full border border-edge bg-white px-[15px] py-2 text-[13px] text-zinc-600 transition-colors hover:border-accent hover:text-accent"
+            >
+              {chip}
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      {/* Edición del día */}
+      <section className="mx-auto max-w-[1100px] px-7 py-6">
+        <div className="flex flex-col items-stretch overflow-hidden rounded-[20px] border border-edge bg-white sm:flex-row">
+          <div className="flex flex-1 flex-col justify-center bg-accent px-9 py-[34px] text-white sm:min-w-[280px]">
+            <h2 className="text-[11.5px] font-semibold uppercase tracking-[0.1em] opacity-70">
+              Edición del día
+            </h2>
+            <span className="my-[10px] mb-[6px] font-serif text-[30px] font-semibold leading-[1.12] tracking-[-0.01em]">
+              {dayLine}
+              <br />
+              {yearLine}
+            </span>
+            <span className="text-[14px] opacity-[0.78]">Edición vigente</span>
+          </div>
+          <div className="flex flex-1 flex-col justify-center gap-[6px] px-9 py-[30px] sm:min-w-[300px] sm:flex-[2]">
+            {[
+              { name: "Edición Matutina", sub: "Consultar publicaciones" },
+              { name: "Edición Vespertina", sub: "Consultar publicaciones" },
+            ].map((row, index) => (
+              <Link
+                key={row.name}
+                href="/notas"
+                className={`flex items-center justify-between py-4 text-left transition hover:opacity-70 ${
+                  index === 0 ? "border-b border-line-soft" : ""
+                }`}
+              >
+                <span>
+                  <span className="block text-[15px] font-semibold">
+                    {row.name}
+                  </span>
+                  <span className="text-[13px] text-zinc-400">{row.sub}</span>
+                </span>
+                <span className="flex items-center gap-[5px] text-[13px] font-semibold text-accent">
+                  Abrir <ChevronRight />
+                </span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Más consultados */}
+      <section className="mx-auto max-w-[1100px] px-7 pb-[72px] pt-10">
+        <div className="mb-2 flex items-baseline justify-between">
+          <h2 className="font-serif text-[23px] font-semibold tracking-[-0.01em]">
+            Más consultados esta semana
+          </h2>
+          <Link
+            href="/notas"
+            className="text-[13.5px] font-medium text-accent"
+          >
+            Ver todos
+          </Link>
+        </div>
+        <ul className="border-t border-line">
+          {docs.map((doc, index) => (
+            <li key={doc.id}>
+              <Link
+                href={`/notas/${doc.id}`}
+                className="flex items-center gap-[22px] border-b border-line-soft px-[6px] py-5 text-left transition-colors hover:bg-[#fafafa]"
+              >
+                <span className="w-[26px] flex-none text-center font-serif text-[17px] text-[#c4c4c9]">
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <span className="hidden w-[104px] flex-none sm:block">
+                  <span className="inline-block rounded-md bg-accent-tint px-[9px] py-[3px] text-[10.5px] font-semibold tracking-[0.04em] text-accent">
+                    {doc.tipo}
+                  </span>
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-[15.5px] font-medium leading-[1.35] text-zinc-800">
+                    {doc.titulo}
+                  </span>
+                  {doc.dependencia && (
+                    <span className="mt-[3px] block text-[13px] text-zinc-400">
+                      {doc.dependencia}
+                    </span>
+                  )}
+                </span>
+                <span className="hidden w-[110px] flex-none text-right text-[12.5px] text-[#bcbcc2] sm:block">
+                  {doc.fecha}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,29 +1,31 @@
-import { format } from "date-fns";
+const FOOTER_LINKS = [
+  { label: "Accesibilidad", href: "#" },
+  { label: "Términos", href: "#" },
+  { label: "Contacto", href: "#" },
+];
 
 export default function Footer() {
   return (
-    <footer className="bg-white">
-      <div className="max-w-(--breakpoint-xl) mx-auto py-12 px-4 overflow-hidden sm:px-6 lg:px-8">
-        <div className="mt-8 flex justify-center">
-          <a
-            href="https://github.com/antoniotorres"
-            className="ml-6 text-gray-500 hover:text-gray-600"
-          >
-            <span className="sr-only">GitHub</span>
-            <svg className="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
-              <path
-                fillRule="evenodd"
-                d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
-                clipRule="evenodd"
-              />
-            </svg>
-          </a>
+    <footer className="border-t border-line bg-[#fafafa]">
+      <div className="mx-auto flex max-w-[1100px] flex-wrap items-center justify-between gap-6 px-4 py-10 sm:px-7">
+        <div className="flex items-center gap-[11px]">
+          <span className="grid h-[30px] w-[30px] place-items-center rounded-lg bg-accent text-[11.5px] font-bold text-white">
+            DOF
+          </span>
+          <span className="text-[13px] text-zinc-400">
+            Diario Oficial de la Federación · Concepto de rediseño
+          </span>
         </div>
-        <div className="mt-8">
-          <p className="text-center text-base leading-6 text-gray-900">
-            &copy; {format(new Date(), "yyyy")} Antonio Torres y Datos del
-            Gobierno de Mexico
-          </p>
+        <div className="flex gap-[22px] text-[13px] text-zinc-500">
+          {FOOTER_LINKS.map((link) => (
+            <a
+              key={link.label}
+              href={link.href}
+              className="transition-colors hover:text-ink"
+            >
+              {link.label}
+            </a>
+          ))}
         </div>
       </div>
     </footer>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,22 +1,101 @@
-import Image from "next/image";
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+
+const NAV_LINKS = [
+  { label: "Ediciones", href: "/notas" },
+  { label: "Dependencias", href: "#" },
+  { label: "Ayuda", href: "#" },
+];
+
+function SearchIcon({ size = 15 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="#9a9a9f"
+      strokeWidth={2.2}
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="7" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  );
+}
 
 export default function Header() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+
+  const isHome = pathname === "/";
+
+  function onSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const trimmed = query.trim();
+    router.push(trimmed ? `/?q=${encodeURIComponent(trimmed)}` : "/");
+  }
+
   return (
-    <header className="relative bg-white">
-      <div className="relative z-20 shadow-sm">
-        <div className="max-w-7xl mx-auto flex justify-between items-center px-4 py-5 sm:px-6 sm:py-4 lg:px-8 md:justify-start md:space-x-10">
-          <div>
-            <span className="sr-only">Diario Oficial de la Fedaración</span>
-            <Image
-              src="/sello.png"
-              alt="Sello de Mexico"
-              width={40}
-              height={40}
-              priority
-            />
+    <header className="sticky top-0 z-50 border-b border-line bg-[#fdfdfc]/[0.82] backdrop-blur-xl backdrop-saturate-[1.8]">
+      <div className="mx-auto flex h-[60px] max-w-[1180px] items-center gap-4 px-4 sm:gap-6 sm:px-7">
+        <Link href="/" className="flex items-center gap-[11px]">
+          <span className="grid h-[34px] w-[34px] place-items-center rounded-[9px] bg-accent text-[13px] font-bold tracking-[0.04em] text-white">
+            DOF
+          </span>
+          <span className="flex flex-col text-left leading-[1.1]">
+            <span className="text-[14.5px] font-semibold tracking-[-0.01em]">
+              Diario Oficial
+            </span>
+            <span className="text-[11px] tracking-[0.01em] text-zinc-500">
+              de la Federación
+            </span>
+          </span>
+        </Link>
+
+        {!isHome && (
+          <form
+            onSubmit={onSubmit}
+            role="search"
+            className="mx-auto hidden max-w-[420px] flex-1 sm:block"
+          >
+            <div className="flex h-[38px] items-center gap-[9px] rounded-[10px] border border-edge bg-field px-[14px] focus-within:border-accent focus-within:ring-2 focus-within:ring-accent/30">
+              <SearchIcon />
+              <input
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Buscar publicaciones"
+                aria-label="Buscar publicaciones"
+                className="min-w-0 flex-1 border-none bg-transparent text-[14px] text-ink placeholder:text-zinc-500 focus:outline-none"
+              />
+            </div>
+          </form>
+        )}
+
+        <nav className="ml-auto flex items-center gap-1">
+          <div className="hidden items-center gap-1 md:flex">
+            {NAV_LINKS.map((link) => (
+              <Link
+                key={link.label}
+                href={link.href}
+                className="rounded-lg px-[13px] py-2 text-[13.5px] text-zinc-600 transition-colors hover:bg-field"
+              >
+                {link.label}
+              </Link>
+            ))}
           </div>
-          <div>Diaro Oficial de la Fedaración</div>
-        </div>
+          <button
+            type="button"
+            className="ml-2 rounded-[9px] bg-accent px-4 py-2 text-[13.5px] font-semibold text-white transition hover:brightness-110"
+          >
+            Suscribirse
+          </button>
+        </nav>
       </div>
     </header>
   );

--- a/components/home/HeroSearch.tsx
+++ b/components/home/HeroSearch.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import type { DocCard } from "@/lib/sampleDocs";
+
+const LISTBOX_ID = "dof-search-suggestions";
+
+function SearchIcon({
+  size,
+  color,
+  width = 2.1,
+}: {
+  size: number;
+  color: string;
+  width?: number;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke={color}
+      strokeWidth={width}
+      aria-hidden="true"
+    >
+      <circle cx="11" cy="11" r="7" />
+      <path d="m21 21-4.3-4.3" />
+    </svg>
+  );
+}
+
+export default function HeroSearch({
+  docs,
+  initialQuery = "",
+}: {
+  docs: DocCard[];
+  initialQuery?: string;
+}) {
+  const router = useRouter();
+  const [query, setQuery] = useState(initialQuery);
+  const [focused, setFocused] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // ⌘K / Ctrl-K focuses the search, matching the keyboard hint.
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        inputRef.current?.focus();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  // When arriving with a URL query (e.g. from the header search), focus the
+  // input so the suggestions are visible. The parent remounts this component
+  // via `key={initialQuery}`, so `useState(initialQuery)` already seeds the
+  // text — no state sync needed here.
+  useEffect(() => {
+    if (initialQuery) inputRef.current?.focus();
+  }, [initialQuery]);
+
+  const suggestions = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [];
+    return docs
+      .filter((doc) =>
+        `${doc.titulo} ${doc.dependencia ?? ""} ${doc.tipo}`
+          .toLowerCase()
+          .includes(q),
+      )
+      .slice(0, 6);
+  }, [docs, query]);
+
+  const showSuggestions = focused && suggestions.length > 0;
+  const activeId =
+    showSuggestions && activeIndex >= 0
+      ? `${LISTBOX_ID}-${activeIndex}`
+      : undefined;
+
+  function onKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (!showSuggestions) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      setActiveIndex((i) => (i + 1) % suggestions.length);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      setActiveIndex((i) => (i <= 0 ? suggestions.length - 1 : i - 1));
+    } else if (event.key === "Enter") {
+      const target = suggestions[activeIndex >= 0 ? activeIndex : 0];
+      if (target) {
+        event.preventDefault();
+        router.push(`/notas/${target.id}`);
+      }
+    } else if (event.key === "Escape") {
+      setFocused(false);
+      inputRef.current?.blur();
+    }
+  }
+
+  return (
+    <div className="relative mx-auto max-w-[600px]">
+      <div className="flex h-[60px] items-center gap-[13px] rounded-2xl border border-[#e2e2e0] bg-white px-[22px] shadow-[0_1px_2px_rgba(0,0,0,0.03),0_8px_28px_rgba(0,0,0,0.05)] focus-within:border-accent focus-within:ring-2 focus-within:ring-accent/30">
+        <SearchIcon size={21} color="#9a9a9f" />
+        <input
+          ref={inputRef}
+          type="search"
+          role="combobox"
+          aria-expanded={showSuggestions}
+          aria-controls={LISTBOX_ID}
+          aria-autocomplete="list"
+          aria-activedescendant={activeId}
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setFocused(true);
+            setActiveIndex(-1);
+          }}
+          onFocus={() => setFocused(true)}
+          onBlur={() => window.setTimeout(() => setFocused(false), 130)}
+          onKeyDown={onKeyDown}
+          placeholder="Busca por tema, dependencia o número de documento…"
+          aria-label="Buscar publicaciones"
+          className="min-w-0 flex-1 border-none bg-transparent text-[17px] text-ink placeholder:text-zinc-500 focus:outline-none"
+        />
+        <kbd className="hidden rounded-md border border-edge px-[7px] py-[3px] text-[11px] text-zinc-400 sm:block">
+          ⌘K
+        </kbd>
+      </div>
+
+      {showSuggestions && (
+        <div className="absolute left-0 right-0 top-[70px] z-30 animate-[sugIn_0.16s_ease] overflow-hidden rounded-[14px] border border-line bg-white text-left shadow-[0_12px_40px_rgba(0,0,0,0.12)]">
+          <div className="px-[18px] pb-[6px] pt-[10px] text-[11px] font-semibold uppercase tracking-[0.06em] text-zinc-400">
+            Sugerencias
+          </div>
+          <ul id={LISTBOX_ID} role="listbox" aria-label="Sugerencias">
+            {suggestions.map((doc, index) => (
+              <li
+                key={doc.id}
+                id={`${LISTBOX_ID}-${index}`}
+                role="option"
+                aria-selected={index === activeIndex}
+              >
+                <Link
+                  href={`/notas/${doc.id}`}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  className={`flex w-full items-center gap-[13px] px-[18px] py-[11px] text-left ${
+                    index === activeIndex ? "bg-[#f7f7f6]" : ""
+                  }`}
+                >
+                  <SearchIcon size={16} color="#bfbfc4" width={2} />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[14px] font-medium text-zinc-800">
+                      {doc.titulo}
+                    </span>
+                    <span className="block text-[12px] text-zinc-400">
+                      {doc.dependencia ?? doc.tipo}
+                    </span>
+                  </span>
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="#cfcfd4"
+                    strokeWidth={2}
+                    aria-hidden="true"
+                  >
+                    <path d="m9 18 6-6-6-6" />
+                  </svg>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/reader/DocToc.tsx
+++ b/components/reader/DocToc.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import type { TocItem } from "@/lib/toc";
+
+export default function DocToc({ items }: { items: TocItem[] }) {
+  const [activeId, setActiveId] = useState(items[0]?.id ?? "");
+
+  useEffect(() => {
+    const headings = items
+      .map((item) => document.getElementById(item.id))
+      .filter((el): el is HTMLElement => el !== null);
+    if (headings.length === 0) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visible = entries
+          .filter((entry) => entry.isIntersecting)
+          .sort((a, b) => a.boundingClientRect.top - b.boundingClientRect.top);
+        if (visible[0]?.target.id) setActiveId(visible[0].target.id);
+      },
+      { rootMargin: "-80px 0px -70% 0px", threshold: 0 },
+    );
+
+    headings.forEach((heading) => observer.observe(heading));
+    return () => observer.disconnect();
+  }, [items]);
+
+  function onClick(event: React.MouseEvent<HTMLAnchorElement>, id: string) {
+    const target = document.getElementById(id);
+    if (!target) return;
+    event.preventDefault();
+    target.scrollIntoView({ behavior: "smooth", block: "start" });
+    setActiveId(id);
+    history.replaceState(null, "", `#${id}`);
+  }
+
+  return (
+    <div className="rounded-2xl border border-edge bg-white px-[22px] py-5">
+      <span className="text-[11px] font-semibold uppercase tracking-[0.06em] text-zinc-400">
+        En esta publicación
+      </span>
+      <nav className="mt-3 flex flex-col" aria-label="En esta publicación">
+        {items.map((item) => {
+          const isActive = item.id === activeId;
+          return (
+            <a
+              key={item.id}
+              href={`#${item.id}`}
+              onClick={(event) => onClick(event, item.id)}
+              style={{ paddingLeft: item.level >= 3 ? 24 : 12 }}
+              className={`border-l-2 py-[7px] text-[13.5px] transition-colors ${
+                isActive
+                  ? "border-accent text-zinc-600"
+                  : "border-line text-zinc-400 hover:text-zinc-600"
+              }`}
+            >
+              {item.text}
+            </a>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/components/reader/ReadingPane.tsx
+++ b/components/reader/ReadingPane.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+
+const MIN_SCALE = 0.8;
+const MAX_SCALE = 1.5;
+const STEP = 0.1;
+const BASE_SIZE = 19;
+
+export default function ReadingPane({
+  content,
+  title,
+}: {
+  content: string;
+  title: string;
+}) {
+  const [scale, setScale] = useState(1);
+  const [copied, setCopied] = useState(false);
+  const [font, setFont] = useState<"serif" | "sans">("serif");
+
+  const fontSize = Math.round(BASE_SIZE * scale * 10) / 10;
+
+  async function share() {
+    if (typeof window === "undefined") return;
+    const url = window.location.href;
+    if (navigator.share) {
+      try {
+        await navigator.share({ title, url });
+      } catch {
+        // User dismissed the share sheet — nothing to do.
+      }
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable; fail silently.
+    }
+  }
+
+  return (
+    <>
+      {/* Action bar */}
+      <div className="flex flex-wrap items-center gap-[10px] pb-[26px] pt-[18px]">
+        <button
+          type="button"
+          onClick={() => window.print()}
+          className="inline-flex items-center gap-2 rounded-[10px] bg-accent px-4 py-[9px] text-[13.5px] font-semibold text-white transition hover:brightness-110"
+        >
+          <svg
+            width="15"
+            height="15"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+          >
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <path d="M7 10l5 5 5-5" />
+            <path d="M12 15V3" />
+          </svg>
+          Descargar PDF
+        </button>
+        <button
+          type="button"
+          onClick={share}
+          className="inline-flex items-center gap-2 rounded-[10px] border border-edge px-[14px] py-[9px] text-[13.5px] text-zinc-700 transition hover:bg-[#f7f7f6]"
+        >
+          <svg
+            width="15"
+            height="15"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            aria-hidden="true"
+          >
+            <circle cx="18" cy="5" r="3" />
+            <circle cx="6" cy="12" r="3" />
+            <circle cx="18" cy="19" r="3" />
+            <path d="m8.6 13.5 6.8 4M15.4 6.5l-6.8 4" />
+          </svg>
+          {copied ? "Enlace copiado" : "Compartir"}
+        </button>
+        <div className="ml-auto flex items-center gap-2">
+          <div
+            role="group"
+            aria-label="Tipo de letra"
+            className="flex items-center gap-[2px] rounded-[10px] border border-edge p-[3px]"
+          >
+            {(["serif", "sans"] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setFont(option)}
+                aria-pressed={font === option}
+                className={`rounded-[7px] px-[10px] py-[6px] text-[12.5px] capitalize transition ${
+                  font === option
+                    ? "bg-field font-medium text-ink"
+                    : "text-zinc-600 hover:bg-field"
+                }`}
+              >
+                {option}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center gap-[2px] rounded-[10px] border border-edge p-[3px]">
+            <button
+              type="button"
+              onClick={() => setScale((s) => Math.max(MIN_SCALE, s - STEP))}
+              disabled={scale <= MIN_SCALE}
+              aria-label="Reducir tamaño de texto"
+              className="grid h-[30px] w-8 place-items-center rounded-[7px] text-[13px] text-zinc-600 transition hover:bg-field disabled:opacity-40"
+            >
+              A−
+            </button>
+            <button
+              type="button"
+              onClick={() => setScale((s) => Math.min(MAX_SCALE, s + STEP))}
+              disabled={scale >= MAX_SCALE}
+              aria-label="Aumentar tamaño de texto"
+              className="grid h-[30px] w-8 place-items-center rounded-[7px] text-[17px] text-zinc-600 transition hover:bg-field disabled:opacity-40"
+            >
+              A+
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div
+        className="dof-prose"
+        style={{
+          fontSize: `${fontSize}px`,
+          fontFamily:
+            font === "sans"
+              ? "var(--font-public-sans), system-ui, sans-serif"
+              : undefined,
+        }}
+        dangerouslySetInnerHTML={{ __html: content }}
+      />
+    </>
+  );
+}

--- a/lib/getNote.ts
+++ b/lib/getNote.ts
@@ -1,4 +1,4 @@
-import { formatISO, parse } from "date-fns";
+import { formatISO, isValid, parse } from "date-fns";
 
 import { uploadFile } from "./aws";
 import { sanitizeHTML } from "./sanitize";
@@ -39,13 +39,12 @@ function findMetadata(data: string) {
   );
 
   const dofMatch = data.match(/<b>DOF:(.*)<\/b>/)?.[0] ?? "";
-  const published_at = formatISO(
-    parse(
-      dofMatch.replace("<b>DOF:", "").replace("</b>", "").trim(),
-      "dd/MM/yyyy",
-      new Date(),
-    ),
-  );
+  const dateText = dofMatch.replace("<b>DOF:", "").replace("</b>", "").trim();
+  // Guard against an unexpected/malformed date: don't let formatISO throw on an
+  // Invalid Date and sink an otherwise-valid note. Downstream formatters treat
+  // an empty published_at gracefully.
+  const parsed = parse(dateText, "dd/MM/yyyy", new Date());
+  const published_at = isValid(parsed) ? formatISO(parsed) : "";
 
   return { title, published_at };
 }

--- a/lib/recentNotes.ts
+++ b/lib/recentNotes.ts
@@ -1,0 +1,118 @@
+import "server-only";
+
+import { format, parseISO } from "date-fns";
+import { es } from "date-fns/locale";
+
+import { getNoteFiles } from "./aws";
+import { getNote, type Note } from "./getNote";
+import { SAMPLE_DOCS, type DocCard } from "./sampleDocs";
+
+export type { DocCard } from "./sampleDocs";
+
+/**
+ * DOF titles almost always begin with the instrument type in caps
+ * ("DECRETO por el que…", "ACUERDO …"). We derive a short badge label from
+ * that prefix. Order matters: longer / more specific prefixes come first.
+ */
+const TIPO_RULES: { prefix: string; label: string }[] = [
+  { prefix: "NORMA OFICIAL MEXICANA", label: "NOM" },
+  { prefix: "PROYECTO DE NORMA OFICIAL MEXICANA", label: "PROY-NOM" },
+  { prefix: "DECRETO", label: "DECRETO" },
+  { prefix: "ACUERDO", label: "ACUERDO" },
+  { prefix: "RESOLUCION", label: "RESOLUCIÓN" },
+  { prefix: "CONVOCATORIA", label: "CONVOCATORIA" },
+  { prefix: "AVISO", label: "AVISO" },
+  { prefix: "OFICIO", label: "OFICIO" },
+  { prefix: "CIRCULAR", label: "CIRCULAR" },
+  { prefix: "LINEAMIENTOS", label: "LINEAMIENTOS" },
+  { prefix: "REGLAS", label: "REGLAS" },
+  { prefix: "REGLAMENTO", label: "REGLAMENTO" },
+  { prefix: "MANUAL", label: "MANUAL" },
+  { prefix: "PROGRAMA", label: "PROGRAMA" },
+  { prefix: "ESTATUTO", label: "ESTATUTO" },
+  { prefix: "EXTRACTO", label: "EXTRACTO" },
+  { prefix: "MODIFICACION", label: "MODIFICACIÓN" },
+  { prefix: "NOTIFICACION", label: "NOTIFICACIÓN" },
+  { prefix: "SENTENCIA", label: "SENTENCIA" },
+  { prefix: "LISTA", label: "LISTA" },
+  { prefix: "LEY", label: "LEY" },
+];
+
+/** Strip accents and upper-case for prefix matching. */
+function normalize(text: string): string {
+  return text
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toUpperCase()
+    .trim();
+}
+
+export function deriveTipo(title: string): string {
+  const normalized = normalize(title);
+  for (const { prefix, label } of TIPO_RULES) {
+    if (normalized.startsWith(prefix)) return label;
+  }
+  return "DOCUMENTO";
+}
+
+function toCard(id: string, note: Note): DocCard | null {
+  const iso = note.metadata.published_at;
+  let fecha = "";
+  let publishedAt = iso;
+  try {
+    const parsed = parseISO(iso);
+    fecha = format(parsed, "d LLL yyyy", { locale: es }).replace(/\./g, "");
+    publishedAt = parsed.toISOString();
+  } catch {
+    // Keep the raw value if the stored date can't be parsed.
+    fecha = iso;
+  }
+
+  const titulo = note.metadata.title?.trim();
+  if (!titulo) return null;
+
+  return {
+    id,
+    tipo: deriveTipo(titulo),
+    titulo,
+    fecha,
+    publishedAt,
+    folio: id,
+  };
+}
+
+/**
+ * Return the most recently published notes as display cards. Falls back to the
+ * curated sample documents whenever S3 is unavailable, unconfigured, or empty,
+ * so the redesign always has content to render.
+ */
+export async function getRecentDocs(limit = 6): Promise<DocCard[]> {
+  try {
+    const files = await getNoteFiles();
+    if (files.length === 0) return SAMPLE_DOCS.slice(0, limit);
+
+    const recent = [...files]
+      .sort(
+        (a, b) =>
+          (b.lastModified?.getTime() ?? 0) - (a.lastModified?.getTime() ?? 0),
+      )
+      .slice(0, limit);
+
+    const cards = await Promise.all(
+      recent.map(async (file) => {
+        try {
+          return toCard(file.id, await getNote(file.id));
+        } catch (error) {
+          console.error(`Failed to load note ${file.id}`, error);
+          return null;
+        }
+      }),
+    );
+
+    const resolved = cards.filter((card): card is DocCard => card !== null);
+    return resolved.length > 0 ? resolved : SAMPLE_DOCS.slice(0, limit);
+  } catch (error) {
+    console.error(error);
+    return SAMPLE_DOCS.slice(0, limit);
+  }
+}

--- a/lib/sampleDocs.ts
+++ b/lib/sampleDocs.ts
@@ -1,0 +1,131 @@
+/**
+ * Curated concept documents used as a graceful fallback for the home and
+ * listing views when S3 is not configured (e.g. local dev without
+ * credentials) or no notes have been cached yet. Mirrors the sample data in
+ * the DOF.dc.html design so the redesign always renders fully.
+ */
+export interface DocCard {
+  /** Note id — the S3 object key without `.json` (links to /notas/[id]). */
+  id: string;
+  tipo: string;
+  titulo: string;
+  dependencia?: string;
+  /** Short, human display date, e.g. "16 jun 2026". */
+  fecha: string;
+  /** ISO 8601 publication date, used for sorting and full-date formatting. */
+  publishedAt: string;
+  folio?: string;
+  edicion?: string;
+  /** True when this is concept/fallback data rather than a real note. */
+  isSample?: boolean;
+}
+
+/** Shape-compatible with lib/getNote `Note` (kept local to avoid importing the
+ *  server-only data layer into this shared module). */
+export interface SampleNote {
+  metadata: { title: string; published_at: string };
+  content: string;
+}
+
+/** Representative legal body shown for concept documents (mirrors DOF.dc.html).
+ *  Its `<h2>` headings drive the "En esta publicación" table of contents. */
+const SAMPLE_BODY = `<p>Al margen un sello con el Escudo Nacional, que dice: Estados Unidos Mexicanos.— Poder Ejecutivo Federal.— Secretaría de Estado correspondiente. Con fundamento en las disposiciones legales aplicables, se expide el presente instrumento para los efectos conducentes.</p>
+<p>Que de conformidad con lo dispuesto en el artículo correspondiente de la Constitución Política de los Estados Unidos Mexicanos, corresponde al Estado garantizar la publicidad y certeza jurídica de los actos administrativos a través de su publicación en el órgano oficial de difusión.</p>
+<h2>Considerando</h2>
+<p>Que resulta necesario actualizar el marco normativo vigente para armonizarlo con los principios de transparencia, eficiencia administrativa y rendición de cuentas, en beneficio de la población y del adecuado funcionamiento de las instituciones del Estado.</p>
+<p>Que las modificaciones contenidas en el presente instrumento fueron objeto de revisión por las instancias competentes, observándose en todo momento el procedimiento establecido para tal efecto, por lo que he tenido a bien expedir el siguiente:</p>
+<h2>Disposiciones</h2>
+<p><strong>ARTÍCULO PRIMERO.—</strong> Se reforman, adicionan y derogan diversas disposiciones a efecto de precisar los criterios de aplicación, los sujetos obligados y los plazos correspondientes, conforme a lo señalado en los anexos que forman parte integrante del presente.</p>
+<p><strong>ARTÍCULO SEGUNDO.—</strong> Las autoridades competentes adoptarán las medidas administrativas necesarias para dar cumplimiento a lo establecido, dentro del ámbito de sus respectivas atribuciones y sin que ello implique erogaciones adicionales a las previstas.</p>
+<h2>Transitorios</h2>
+<p><strong>PRIMERO.—</strong> El presente instrumento entrará en vigor al día siguiente de su publicación en el Diario Oficial de la Federación.</p>
+<p><strong>SEGUNDO.—</strong> Se derogan todas aquellas disposiciones que se opongan a lo dispuesto en el presente, en lo que corresponda.</p>`;
+
+/**
+ * Concept document body for a sample id, used as a graceful fallback so the
+ * sample links on the home / listing pages remain navigable when S3 and the
+ * upstream DOF source are both unavailable. Returns null for unknown ids.
+ */
+export function getSampleNote(id: string): SampleNote | null {
+  const doc = SAMPLE_DOCS.find((entry) => entry.id === id);
+  if (!doc) return null;
+  return {
+    metadata: { title: doc.titulo, published_at: doc.publishedAt },
+    content: SAMPLE_BODY,
+  };
+}
+
+export const SAMPLE_DOCS: DocCard[] = [
+  {
+    id: "DOF-2026-0616-001",
+    tipo: "DECRETO",
+    dependencia: "Secretaría de Hacienda y Crédito Público",
+    titulo:
+      "Decreto por el que se reforman diversas disposiciones de la Ley de Ingresos sobre Hidrocarburos",
+    fecha: "16 jun 2026",
+    publishedAt: "2026-06-16",
+    folio: "DOF-2026-0616-001",
+    edicion: "Matutina",
+    isSample: true,
+  },
+  {
+    id: "DOF-2026-0616-014",
+    tipo: "ACUERDO",
+    dependencia: "Secretaría de Salud",
+    titulo:
+      "Acuerdo por el que se actualiza el cuadro básico de insumos del sector salud",
+    fecha: "16 jun 2026",
+    publishedAt: "2026-06-16",
+    folio: "DOF-2026-0616-014",
+    edicion: "Matutina",
+    isSample: true,
+  },
+  {
+    id: "DOF-2026-0615-008",
+    tipo: "NOM",
+    dependencia: "Secretaría de Economía",
+    titulo:
+      "Norma Oficial Mexicana de etiquetado de productos electrónicos de consumo",
+    fecha: "15 jun 2026",
+    publishedAt: "2026-06-15",
+    folio: "DOF-2026-0615-008",
+    edicion: "Vespertina",
+    isSample: true,
+  },
+  {
+    id: "DOF-2026-0615-003",
+    tipo: "RESOLUCIÓN",
+    dependencia: "Comisión Reguladora de Energía",
+    titulo:
+      "Resolución sobre las tarifas de suministro básico de energía eléctrica",
+    fecha: "15 jun 2026",
+    publishedAt: "2026-06-15",
+    folio: "DOF-2026-0615-003",
+    edicion: "Matutina",
+    isSample: true,
+  },
+  {
+    id: "DOF-2026-0613-021",
+    tipo: "CONVOCATORIA",
+    dependencia: "Secretaría de Educación Pública",
+    titulo:
+      "Convocatoria al programa nacional de becas para la educación superior",
+    fecha: "13 jun 2026",
+    publishedAt: "2026-06-13",
+    folio: "DOF-2026-0613-021",
+    edicion: "Matutina",
+    isSample: true,
+  },
+  {
+    id: "DOF-2026-0612-005",
+    tipo: "AVISO",
+    dependencia: "Instituto Nacional Electoral",
+    titulo:
+      "Aviso sobre el calendario de actividades del proceso de participación ciudadana",
+    fecha: "12 jun 2026",
+    publishedAt: "2026-06-12",
+    folio: "DOF-2026-0612-005",
+    edicion: "Vespertina",
+    isSample: true,
+  },
+];

--- a/lib/toc.ts
+++ b/lib/toc.ts
@@ -1,0 +1,54 @@
+export interface TocItem {
+  id: string;
+  text: string;
+  level: number;
+}
+
+function slugify(text: string, used: Set<string>): string {
+  const base =
+    text
+      .normalize("NFD")
+      .replace(/\p{Diacritic}/gu, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .trim()
+      .replace(/\s+/g, "-")
+      .slice(0, 60) || "seccion";
+
+  let id = base;
+  let n = 2;
+  while (used.has(id)) id = `${base}-${n++}`;
+  used.add(id);
+  return id;
+}
+
+/**
+ * Build a table of contents from the `<h1>`–`<h3>` headings in a note's HTML,
+ * injecting a stable `id` on each so the sidebar can link and scroll to it.
+ * Returns the (possibly rewritten) html and the heading list. If a document
+ * has no headings the toc is empty and the sidebar card is simply omitted.
+ */
+export function buildToc(html: string): { html: string; toc: TocItem[] } {
+  const toc: TocItem[] = [];
+  const used = new Set<string>();
+
+  const rewritten = html.replace(
+    /<(h[1-3])\b([^>]*)>([\s\S]*?)<\/\1>/gi,
+    (match, tag: string, attrs: string, inner: string) => {
+      const text = inner
+        .replace(/<[^>]+>/g, "")
+        .replace(/\s+/g, " ")
+        .trim();
+      if (!text) return match;
+
+      const id = slugify(text, used);
+      toc.push({ id, text, level: Number(tag[1]) });
+
+      // Replace any existing id, then inject ours.
+      const cleanedAttrs = attrs.replace(/\s*id\s*=\s*("[^"]*"|'[^']*')/i, "");
+      return `<${tag}${cleanedAttrs} id="${id}">${inner}</${tag}>`;
+    },
+  );
+
+  return { html: rewritten, toc };
+}


### PR DESCRIPTION
Implements the **"Rediseño web DOF México"** Claude Design (`DOF.dc.html`) across the site: Public Sans + Source Serif 4 fonts, accent theme tokens, and a sticky blurred header/footer. Adds a new home page (hero search with a live ARIA combobox, "Edición del día" card, "Más consultados" list) and a recent-editions listing at `/notas`, both fed by real S3 notes with a curated concept fallback when S3 is unconfigured. Rebuilds the document view (`/notas/[id]`) into an article + sticky sidebar layout with a title-derived `tipo` badge, reader font zoom and serif/sans toggle, share/print actions, publication metadata, and an auto-generated table of contents with scroll-spy. Introduces `lib/recentNotes`, `lib/sampleDocs`, and `lib/toc`, plus a malformed-date guard in `getNote`, and a restyled 404. Verified with `pnpm lint` + `pnpm build`, browser QA at desktop/mobile, and an adversarial multi-dimension review whose confirmed accessibility findings (focus-visible, combobox keyboard nav, skip link, semantic lists) were applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)