### PR TITLE
fix(deps): force postcss>=8.5.10 to resolve GHSA-qx2v-qp2m-jg93

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "onlyBuiltDependencies": [
       "sharp",
       "unrs-resolver"
-    ]
+    ],
+    "overrides": {
+      "postcss@<8.5.10": ">=8.5.10"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  postcss@<8.5.10: '>=8.5.10'
+
 importers:
 
   .:
@@ -1957,10 +1960,6 @@ packages:
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -4320,7 +4319,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.38
       caniuse-lite: 1.0.30001799
-      postcss: 8.4.31
+      postcss: 8.5.15
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
@@ -4440,12 +4439,6 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.15:
     dependencies:


### PR DESCRIPTION
## What & why

Closes the only open Dependabot security alert ([#120](https://github.com/antoniotorres/dof/security/dependabot/120), **GHSA-qx2v-qp2m-jg93** — moderate XSS via unescaped `</style>` in PostCSS stringify output, affecting `postcss < 8.5.10`).

**Root cause:** `next@16.2.9` pins `postcss@8.4.31` as a transitive dependency. The repo's own direct `postcss` devDependency was already `8.5.15`, so the alert came solely from Next's pinned copy — which is why the auto-generated Dependabot PR (#21, now closed) couldn't fix it.

## Fix

Add a `pnpm.overrides` entry forcing any `postcss < 8.5.10` in the tree to `>=8.5.10`:

```jsonc
"pnpm": {
  "overrides": { "postcss@<8.5.10": ">=8.5.10" }
}
```

After regenerating the lockfile, the graph dedupes to a single `postcss@8.5.15` and `postcss@8.4.31` is removed entirely (stays within the same major, so it's a drop-in for Next's CSS pipeline).

## Verification

- `pnpm why postcss` → every path resolves to `8.5.15` (no `8.4.31`)
- `grep postcss@8.4.31 pnpm-lock.yaml` → none
- `pnpm install --frozen-lockfile` → no drift
- `pnpm typecheck` → clean
- `pnpm build` → green

🤖 Generated with [Claude Code](https://claude.com/claude-code)