### PR TITLE
feat(analytics): add Umami and gate analytics to production deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,16 @@ SERVER_AWS_ACCESS_KEY_ID=
 SERVER_AWS_ACCESS_SECRET=
 
 # Google Analytics measurement ID (e.g. G-XXXXXXXXXX)
-# Exposed to the browser; only loaded in production builds.
+# Exposed to the browser; only loaded on the production deployment
+# (Vercel VERCEL_ENV=production — never on preview deployments or in dev).
 NEXT_PUBLIC_GA_TRACKING_ID=
+
+# Umami — privacy-friendly, cookieless analytics.
+# Exposed to the browser; only loaded on the production deployment
+# (never on preview/dev), and only when BOTH values below are set.
+# Set these for the Production environment only. Leave blank to disable.
+#   NEXT_PUBLIC_UMAMI_WEBSITE_ID — the website id from your Umami dashboard
+#   NEXT_PUBLIC_UMAMI_SRC        — the tracker script URL
+#                                  (e.g. https://analytics.toniotgz.com/script.js)
+NEXT_PUBLIC_UMAMI_WEBSITE_ID=
+NEXT_PUBLIC_UMAMI_SRC=

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ yarn-error.log*
 # secrets / certificates (never commit these)
 *.pem
 *.key
+.env*

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -8,11 +8,17 @@ recommended for production.
 ## What we collect
 
 The app has **no user accounts** and stores **no personal data** about
-visitors. It uses two privacy-conscious analytics services:
+visitors. It uses these privacy-conscious analytics services:
 
 - **Vercel Web Analytics** — aggregated, cookieless page-view metrics. No
   cross-site tracking and no personally identifiable information.
-- **Google Analytics** — loaded **only in production builds** and **only if**
+- **Umami** — self-hosted, cookieless analytics. Loaded **only on the
+  production deployment** (never on preview deployments or in development) and
+  **only if** both `NEXT_PUBLIC_UMAMI_WEBSITE_ID` and `NEXT_PUBLIC_UMAMI_SRC`
+  are configured (see [`app/layout.tsx`](app/layout.tsx)). Collects no personal
+  data and sets no cookies.
+- **Google Analytics** — loaded **only on the production deployment** (never on
+  preview deployments or in development) and **only if**
   `NEXT_PUBLIC_GA_TRACKING_ID` is configured (see
   [`app/layout.tsx`](app/layout.tsx)). Google Analytics uses cookies and
   collects usage data subject to
@@ -27,6 +33,7 @@ visitors. It uses two privacy-conscious analytics services:
 ## Third parties
 
 - **Vercel** — hosting and analytics ([privacy](https://vercel.com/legal/privacy-policy)).
+- **Umami** — self-hosted, cookieless analytics ([privacy](https://umami.is/docs/faq)).
 - **Google** — analytics, when enabled.
 - **AWS S3** — note cache storage.
 

--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@
 
 ## Tech stack
 
-| Area            | Choice                                             |
-| --------------- | -------------------------------------------------- |
-| Framework       | [Next.js 16](https://nextjs.org) (App Router)      |
-| Language        | [TypeScript](https://www.typescriptlang.org)       |
-| UI              | [React 19](https://react.dev)                      |
-| Styling         | [Tailwind CSS v4](https://tailwindcss.com)         |
-| Storage / cache | [AWS S3](https://aws.amazon.com/s3/) (AWS SDK v3)  |
-| Package manager | [pnpm](https://pnpm.io)                            |
-| Runtime         | Node.js 24 (see [`.nvmrc`](.nvmrc))                |
-| Hosting         | [Vercel](https://vercel.com)                       |
-| Analytics       | Vercel Web Analytics + Google Analytics (optional) |
+| Area            | Choice                                                     |
+| --------------- | ---------------------------------------------------------- |
+| Framework       | [Next.js 16](https://nextjs.org) (App Router)              |
+| Language        | [TypeScript](https://www.typescriptlang.org)               |
+| UI              | [React 19](https://react.dev)                              |
+| Styling         | [Tailwind CSS v4](https://tailwindcss.com)                 |
+| Storage / cache | [AWS S3](https://aws.amazon.com/s3/) (AWS SDK v3)          |
+| Package manager | [pnpm](https://pnpm.io)                                    |
+| Runtime         | Node.js 24 (see [`.nvmrc`](.nvmrc))                        |
+| Hosting         | [Vercel](https://vercel.com)                               |
+| Analytics       | Vercel Web Analytics + Umami + Google Analytics (optional) |
 
 ## How it works
 
@@ -107,16 +107,21 @@ Copy [`.env.example`](.env.example) to `.env.local` and fill in the values you
 need. All AWS variables are **server-side only** and are never exposed to the
 browser.
 
-| Variable                     | Required | Description                                           |
-| ---------------------------- | :------: | ----------------------------------------------------- |
-| `SERVER_AWS_REGION`          |   No\*   | AWS region of the S3 bucket.                          |
-| `SERVER_AWS_BUCKET`          |   No\*   | S3 bucket name that holds the cached note JSON files. |
-| `SERVER_AWS_ACCESS_KEY_ID`   |   No\*   | IAM access key id with read/write to the bucket.      |
-| `SERVER_AWS_ACCESS_SECRET`   |   No\*   | IAM secret access key.                                |
-| `NEXT_PUBLIC_GA_TRACKING_ID` |    No    | Google Analytics measurement id (prod builds only).   |
+| Variable                       | Required | Description                                                            |
+| ------------------------------ | :------: | ---------------------------------------------------------------------- |
+| `SERVER_AWS_REGION`            |   No\*   | AWS region of the S3 bucket.                                           |
+| `SERVER_AWS_BUCKET`            |   No\*   | S3 bucket name that holds the cached note JSON files.                  |
+| `SERVER_AWS_ACCESS_KEY_ID`     |   No\*   | IAM access key id with read/write to the bucket.                       |
+| `SERVER_AWS_ACCESS_SECRET`     |   No\*   | IAM secret access key.                                                 |
+| `NEXT_PUBLIC_GA_TRACKING_ID`   |    No    | Google Analytics measurement id (production deploy only, not preview). |
+| `NEXT_PUBLIC_UMAMI_WEBSITE_ID` |  No\*\*  | Umami website id (production deploy only, not preview).                |
+| `NEXT_PUBLIC_UMAMI_SRC`        |  No\*\*  | Umami tracker script URL (production deploy only, not preview).        |
 
 > \* Without S3 the app builds and runs with an empty note listing. Configure
 > all four AWS variables together to enable the cache.
+
+> \*\* Umami loads only when **both** `NEXT_PUBLIC_UMAMI_WEBSITE_ID` and
+> `NEXT_PUBLIC_UMAMI_SRC` are set. Leave either blank to disable.
 
 > [!WARNING]
 > Never commit real credentials. `.env*` files are git-ignored; only

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { Public_Sans, Source_Serif_4 } from "next/font/google";
 import { GoogleAnalytics } from "@next/third-parties/google";
 import { Analytics } from "@vercel/analytics/next";
+import Script from "next/script";
 
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
@@ -24,7 +25,18 @@ const sourceSerif = Source_Serif_4({
   variable: "--font-source-serif",
 });
 
+// Analytics must run ONLY on the production deployment. On Vercel, NODE_ENV is
+// "production" for BOTH production AND preview builds, so it cannot distinguish
+// the two. VERCEL_ENV ("production" | "preview" | "development") is the reliable
+// signal; it is undefined locally, so `next dev` and local builds never track.
+const isProductionDeployment = process.env.VERCEL_ENV === "production";
+
 const gaId = process.env.NEXT_PUBLIC_GA_TRACKING_ID;
+
+// Umami — privacy-friendly, cookieless analytics. Loaded only on the production
+// deployment and only when both the website id and script src are configured.
+const umamiWebsiteId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
+const umamiSrc = process.env.NEXT_PUBLIC_UMAMI_SRC;
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://dof.toniotgz.com"),
@@ -84,10 +96,16 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         </div>
         <Footer />
         <Analytics />
+        {isProductionDeployment && umamiWebsiteId && umamiSrc ? (
+          <Script
+            defer
+            src={umamiSrc}
+            data-website-id={umamiWebsiteId}
+            strategy="afterInteractive"
+          />
+        ) : null}
       </body>
-      {process.env.NODE_ENV === "production" && gaId ? (
-        <GoogleAnalytics gaId={gaId} />
-      ) : null}
+      {isProductionDeployment && gaId ? <GoogleAnalytics gaId={gaId} /> : null}
     </html>
   );
 }


### PR DESCRIPTION
## Summary

Adds **Umami** (privacy-friendly, cookieless) analytics via `next/script` in the root layout, configured by `NEXT_PUBLIC_UMAMI_WEBSITE_ID` and `NEXT_PUBLIC_UMAMI_SRC`. It also gates **both** Umami and the existing Google Analytics on `VERCEL_ENV === "production"` instead of `NODE_ENV` — since `NODE_ENV` is `"production"` for Vercel preview builds too, the old check could track preview traffic, whereas `VERCEL_ENV` ensures preview deployments and local dev never track. The new env vars and behaviour are documented in `.env.example`, `README.md`, and `PRIVACY.md`, and all `.env*` files are git-ignored. (Vercel Web Analytics and Google Analytics were already present on `main`; this PR adds Umami and hardens the gating.)

## Related issues

N/A

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [ ] ♻️ Refactor
- [x] 📝 Docs
- [ ] 🔧 Chore / tooling / CI

## How was this tested?

- `pnpm lint`, `pnpm typecheck`, and `pnpm build` pass locally.
- Verified the gate by building with `VERCEL_ENV=production` (Umami + GA scripts present in the prerendered HTML) and `VERCEL_ENV=preview` (neither present).
- Added `NEXT_PUBLIC_UMAMI_WEBSITE_ID` and `NEXT_PUBLIC_UMAMI_SRC` to the Vercel **Production** environment only (verified via `vercel env ls production`). Umami goes live on the next production deploy.

## Checklist

- [x] Branch is up to date with `main`.
- [x] `pnpm lint`, `pnpm typecheck`, and `pnpm build` pass locally.
- [x] Code is formatted (`pnpm format:fix`).
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] No secrets, credentials, or `.env` files are committed.
- [x] Docs updated if behavior or setup changed.
