### PR TITLE
feat(r2): Migrate storage from AWS S3 to Cloudflare R2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,13 @@
-# AWS S3 — storage for the cached DOF note JSON files
-# (server-side only; never exposed to the browser)
-SERVER_AWS_REGION=
-SERVER_AWS_BUCKET=
-SERVER_AWS_ACCESS_KEY_ID=
-SERVER_AWS_ACCESS_SECRET=
+# Cloudflare R2 — storage for the cached DOF note JSON files.
+# R2 is S3-compatible. Reads are served from the public bucket URL; writes and
+# listing use the R2 S3 API (server-side only; never exposed to the browser).
+# Create an R2 API token in the dashboard: R2 > Manage R2 API Tokens.
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET=
+# Public read base URL, e.g. https://pub-xxxxxxxx.r2.dev or a custom domain.
+R2_PUBLIC_URL=
 
 # Google Analytics measurement ID (e.g. G-XXXXXXXXXX)
 # Exposed to the browser; only loaded on the production deployment

--- a/app/notas/[id]/page.tsx
+++ b/app/notas/[id]/page.tsx
@@ -5,7 +5,7 @@ import { es } from "date-fns/locale";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 
-import { getNoteFiles } from "@/lib/aws";
+import { getNoteFiles } from "@/lib/r2";
 import { getNote, type Note } from "@/lib/getNote";
 import { getSampleNote } from "@/lib/sampleDocs";
 import { deriveTipo } from "@/lib/recentNotes";
@@ -174,7 +174,9 @@ export default async function NotePage({
                 </dd>
               </div>
               <div>
-                <dt className="mb-[2px] text-[12px] text-zinc-400">Folio DOF</dt>
+                <dt className="mb-[2px] text-[12px] text-zinc-400">
+                  Folio DOF
+                </dt>
                 <dd className="text-[14px] font-medium tabular-nums text-zinc-800">
                   {id}
                 </dd>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from "next";
 
-import { getNoteFiles } from "@/lib/aws";
+import { getNoteFiles } from "@/lib/r2";
 
 const BASE_URL = "https://dof.toniotgz.com";
 

--- a/lib/getNote.ts
+++ b/lib/getNote.ts
@@ -1,6 +1,6 @@
 import { formatISO, isValid, parse } from "date-fns";
 
-import { uploadFile } from "./aws";
+import { uploadFile } from "./r2";
 import { sanitizeHTML } from "./sanitize";
 
 export interface Note {
@@ -16,13 +16,11 @@ async function fetchFromSource(id: string) {
   return data;
 }
 
-async function fetchFromS3(id: string) {
-  if (!process.env.SERVER_AWS_BUCKET || !process.env.SERVER_AWS_REGION) {
-    throw new Error("S3 is not configured");
+async function fetchFromR2(id: string) {
+  if (!process.env.R2_PUBLIC_URL) {
+    throw new Error("R2 is not configured");
   }
-  const response = await fetch(
-    `https://${process.env.SERVER_AWS_BUCKET}.s3.${process.env.SERVER_AWS_REGION}.amazonaws.com/${id}.json`,
-  );
+  const response = await fetch(`${process.env.R2_PUBLIC_URL}/${id}.json`);
   const data = await response.text();
   if (response.status === 200) {
     return data;
@@ -50,35 +48,35 @@ function findMetadata(data: string) {
 }
 
 /**
- * Fetch a note by id. Tries the S3 cache first; on a miss it downloads the
- * original DOF page, sanitizes it, caches it back to S3, and returns it.
+ * Fetch a note by id. Tries the R2 cache first; on a miss it downloads the
+ * original DOF page, sanitizes it, caches it back to R2, and returns it.
  */
 export async function getNote(id: string): Promise<Note> {
   const filename = `${id}.json`;
 
   try {
-    const s3File = await fetchFromS3(id);
-    console.log("File Found in S3 ... OK");
-    if (s3File) {
-      return JSON.parse(s3File) as Note;
+    const r2File = await fetchFromR2(id);
+    console.log("File Found in R2 ... OK");
+    if (r2File) {
+      return JSON.parse(r2File) as Note;
     }
   } catch (error) {
     console.error(error);
   }
 
   // Download file from original DOF page
-  console.log("Not Found in S3 ... Fallback to DOF");
+  console.log("Not Found in R2 ... Fallback to DOF");
   const source = await fetchFromSource(id);
   const metadata = findMetadata(source);
   const content = sanitizeHTML(source);
   const file: Note = { metadata, content };
 
-  // Cache back to S3, but never let a write failure break the read path: the
+  // Cache back to R2, but never let a write failure break the read path: the
   // note was already fetched successfully, so we always return it.
   try {
     await uploadFile(filename, JSON.stringify(file));
   } catch (error) {
-    console.error("S3 cache write failed", error);
+    console.error("R2 cache write failed", error);
   }
   return file;
 }

--- a/lib/r2.ts
+++ b/lib/r2.ts
@@ -7,18 +7,20 @@ import {
   type _Object,
 } from "@aws-sdk/client-s3";
 
-// Server-side S3 client. Credentials come from server-only env vars and are
-// never exposed to the browser (see the `server-only` import above).
-const s3 = new S3Client({
-  region: process.env.SERVER_AWS_REGION,
+// Server-side Cloudflare R2 client. R2 is S3-compatible, so we use the AWS S3
+// SDK pointed at the R2 endpoint. Credentials come from server-only env vars
+// and are never exposed to the browser (see the `server-only` import above).
+const r2 = new S3Client({
+  region: "auto",
+  endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
   credentials: {
-    accessKeyId: process.env.SERVER_AWS_ACCESS_KEY_ID ?? "",
-    secretAccessKey: process.env.SERVER_AWS_ACCESS_SECRET ?? "",
+    accessKeyId: process.env.R2_ACCESS_KEY_ID ?? "",
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY ?? "",
   },
 });
 
 export interface NoteFile {
-  /** The note id (the S3 object key without the `.json` extension). */
+  /** The note id (the R2 object key without the `.json` extension). */
   id: string;
   lastModified?: Date;
 }
@@ -29,19 +31,19 @@ export interface NoteFile {
  * filtered out.
  */
 export async function getNoteFiles(): Promise<NoteFile[]> {
-  // Without S3 configuration there are no notes to list. Returning an empty
-  // list (instead of letting the AWS SDK throw) keeps `next build` working in
+  // Without R2 configuration there are no notes to list. Returning an empty
+  // list (instead of letting the SDK throw) keeps `next build` working in
   // environments where the credentials are intentionally absent.
-  if (!process.env.SERVER_AWS_REGION || !process.env.SERVER_AWS_BUCKET) {
+  if (!process.env.R2_ACCOUNT_ID || !process.env.R2_BUCKET) {
     // Logged at error level so a misconfigured deployment (which would ship an
     // empty sitemap / no pre-rendered notes) is visible in production logs.
-    // Pages are still generated on demand at runtime when S3 is reachable.
-    console.error("S3 is not configured; skipping note listing.");
+    // Pages are still generated on demand at runtime when R2 is reachable.
+    console.error("R2 is not configured; skipping note listing.");
     return [];
   }
 
-  const result = await s3.send(
-    new ListObjectsV2Command({ Bucket: process.env.SERVER_AWS_BUCKET }),
+  const result = await r2.send(
+    new ListObjectsV2Command({ Bucket: process.env.R2_BUCKET }),
   );
 
   return (result.Contents ?? [])
@@ -61,9 +63,9 @@ export async function uploadFile(
   filename: string,
   data: string,
 ): Promise<void> {
-  await s3.send(
+  await r2.send(
     new PutObjectCommand({
-      Bucket: process.env.SERVER_AWS_BUCKET,
+      Bucket: process.env.R2_BUCKET,
       Key: filename,
       Body: data,
       ContentType: "application/json",

--- a/lib/recentNotes.ts
+++ b/lib/recentNotes.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { format, parseISO } from "date-fns";
 import { es } from "date-fns/locale";
 
-import { getNoteFiles } from "./aws";
+import { getNoteFiles } from "./r2";
 import { getNote, type Note } from "./getNote";
 import { SAMPLE_DOCS, type DocCard } from "./sampleDocs";
 

--- a/scripts/setup-r2.sh
+++ b/scripts/setup-r2.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# First-time Cloudflare R2 provisioning for this project.
+# Safe for a public repo: reads no secrets from tracked files and writes none.
+
+BUCKET="${R2_BUCKET:-dof-notas}"
+
+echo "==> Checking for wrangler..."
+if ! command -v wrangler >/dev/null 2>&1; then
+  echo "ERROR: wrangler is not installed."
+  echo "Install it with: npm install -g wrangler"
+  exit 1
+fi
+
+echo "==> Checking Cloudflare authentication..."
+if ! wrangler whoami >/dev/null 2>&1; then
+  echo "ERROR: not authenticated. Run: wrangler login"
+  exit 1
+fi
+
+echo "==> Creating R2 bucket '${BUCKET}' (skips if it already exists)..."
+wrangler r2 bucket create "${BUCKET}" || \
+  echo "Bucket may already exist; continuing."
+
+echo "==> Enabling public dev URL for '${BUCKET}'..."
+wrangler r2 bucket dev-url enable "${BUCKET}"
+
+echo ""
+echo "============================================================"
+echo "Setup complete. Set these environment variables in your"
+echo "deploy platform (and .env.local for local dev):"
+echo ""
+echo "  R2_ACCOUNT_ID        (Cloudflare account ID)"
+echo "  R2_ACCESS_KEY_ID     (from an R2 API token)"
+echo "  R2_SECRET_ACCESS_KEY (from an R2 API token)"
+echo "  R2_BUCKET=${BUCKET}"
+echo "  R2_PUBLIC_URL        (the pub-<hash>.r2.dev URL printed above)"
+echo ""
+echo "Create an R2 API token in the Cloudflare dashboard:"
+echo "  R2 > Manage R2 API Tokens > Create API Token"
+echo "(Tokens cannot be created from this script for security.)"
+echo "============================================================"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,7 @@
+name = "dof"
+
+# R2 bucket binding. No secrets here — account ID and credentials are
+# provided via environment variables at runtime (see .env.example).
+[[r2_buckets]]
+binding = "NOTAS"
+bucket_name = "dof-notas"


### PR DESCRIPTION
## Summary

Migrates the note-storage layer from AWS S3 to a Cloudflare R2 public bucket, rebased on the current Next 16 / App Router / pnpm `main`. App behavior is unchanged — only the storage backend.

- `lib/aws.ts` → `lib/r2.ts`: AWS SDK v3 S3 client repointed at the R2 endpoint (`region: "auto"`, `https://<account>.r2.cloudflarestorage.com`). Exports (`getNoteFiles`, `uploadFile`, `NoteFile`) and `server-only` guard preserved.
- `getNote`: reads cached notes from the public bucket URL (`R2_PUBLIC_URL`).
- Importers updated: `app/sitemap.ts`, `app/notas/[id]/page.tsx`, `lib/recentNotes.ts`.
- `.env.example`: `SERVER_AWS_*` → `R2_*`.
- Added `wrangler.toml` (bucket binding only) and `scripts/setup-r2.sh` (provisioning).

## Security (public repo)

No secrets in any tracked file. Credentials come only from env vars: `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET`, `R2_PUBLIC_URL`. `wrangler.toml` carries only the bucket name/binding; `.env.example` documents names only.

## Verification

- `tsc --noEmit` passes; `pnpm build` succeeds on Node 24 **with** live R2 creds (sitemap prerenders, all static pages generate).
- R2 connection verified end-to-end against the provisioned `dof-notas` bucket (PUT / LIST / GET-via-S3 / public-URL 200 / DELETE).

> Supersedes #30, which was based on the pre-rewrite (Next 10) codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)